### PR TITLE
Using correct journald fields, mapping priorities, sending defaults.

### DIFF
--- a/lib/log_journald.js
+++ b/lib/log_journald.js
@@ -48,7 +48,7 @@ var journald = {
       for (key in args[0]) {
         if (args[0].hasOwnProperty(key)) {
           if (typeof args[0][key] == 'string') {
-            strings.push(key + '=' + args[0][key]);
+            strings.push(key.toUpperCase() + '=' + args[0][key]);
           }
           else {
             throw {

--- a/lib/winston_journald.js
+++ b/lib/winston_journald.js
@@ -1,6 +1,8 @@
 /**
  * Winston Transport for outputting to the systemd journal.
  *
+ * See http://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html
+ *
  * (C) 2012 Mark Theunissen
  * MIT (EXPAT) LICENCE
  *
@@ -17,6 +19,8 @@ var util = require('util'),
 var Journald = exports.Journald = function (options) {
   options = options || {};
   this.name = 'journald';
+  this.priority_map = options.priority_map || {};
+  this.default_meta = options.default_meta || {};
 };
 
 /**
@@ -30,21 +34,35 @@ util.inherits(Journald, Transport);
 Journald.prototype.name = 'journald';
 
 /**
- * Write to the log. The priority and level are added to the log message.
+ * Write to the log. The level is added to the log message, along with
+ * the numerical priority, if there is a valid level-to-priority map entry.
  *
- * Any additional fields can be passed in the 'meta' parameter, and are added
- * to the message.
+ * Any additional fields can be passed in the 'event_meta' parameter, which
+ * are added to the message, overriding any fields defined as default_meta.
  */
-Journald.prototype.log = function (level, msg, meta, callback) {
-  meta = meta || {};
+Journald.prototype.log = function (level, msg, event_meta, callback) {
+  meta = this.default_meta || {};
+
+  // Set level
   meta.LEVEL = level;
 
-  msg_split = msg.split('=', 2);
+  // Map level to named PRIORITY field
+  if (this.priority_map[level]) {
+    meta.PRIORITY = this.priority_map[level] + '';
+  }
+
+  // Merge in event_meta key/value pairs (if any)
+  for (var key in event_meta || {}) {
+    meta[key] = event_meta[key];
+  }
+
+  // Split or use message
+  msg_split = (msg || '').split('=', 2);
   if (msg_split.length > 1) {
     meta[msg_split[0]] = msg_split[1];
   }
   else {
-    meta.MSG = msg_split[0];
+    meta.MESSAGE = msg_split[0];
   }
 
   journald.log(meta, callback);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "description": "Log to the systemd journal",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "name": "journald",
   "author": "Mark Theunissen",
   "homepage": "https://github.com/systemd/node-systemd",

--- a/test.js
+++ b/test.js
@@ -17,10 +17,22 @@ winston.add(journald_transport.Journald);
 winston.info('Simple message format');
 winston.info('CUSTOMKEY=Specified a key');
 
-winston.log('error', 'MSG=Multiple messages can be sent', {
+winston.log('error', 'MESSAGE=Multiple messages can be sent', {
   STATE: 'System crashing',
   BECAUSE: 'Someone unplugged it'
 });
+
+
+// Or, create a winston logger instance, passing in options, i.e.
+// default SYSLOG_IDENTIFIER field, or level-to-priority map.
+var transport_instance = new (journald_transport.Journald)({
+  "default_meta": {"SYSLOG_IDENTIFIER": "test"},
+  "priority_map": {"debug": 7, "fatal": 1}
+})
+var log = new winston.Logger(transports: [ transport_instance ])
+log.debug("Something trivial", {ANOTHER_KEY: "ANOTHER_VALUE"})
+log.fatal("This is bad news")
+
 
 // Now log directly using the journald log, you can pass as many string
 // parameters as you like.


### PR DESCRIPTION
This updates the winston transport to use the correct `MESSAGE` field.  Additionally, this adds the ability to specify default key/value pairs on transport creation (i.e. SYSLOG_IDENTIFIER), and attempts to map the `level` string passed by winston into a numerical value for the journald PRIORITY field.
