### PR TITLE
Rely on pkg-config for libsystemd-daemon location

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,7 @@
     {
       "target_name": "journald_cpp",
       "sources": [ "src/journald_cpp.cc" ],
-      'libraries': [ '/lib64/libsystemd-journal.so' ]
+      'libraries': [ "<!@(pkg-config --libs-only-l libsystemd-daemon)" ]
     }
   ]
 }


### PR DESCRIPTION
Hardcoded `.so` location doesn't work everywhere - for example, on i686 systems there's no `/libs64/` at all. See https://github.com/TooTallNate/node-gyp/wiki/%22binding.gyp%22-files-out-in-the-wild for solutions people use. Since `pkg-config` config files for systemd are maintained by systemd developers as evident from `systemd` man pages, I think `pkg-config` is the best solution.
