### PR TITLE
Use libsystemd instead of libsystemd-journal

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,7 @@
     {
       "target_name": "journald_cpp",
       "sources": [ "src/journald_cpp.cc" ],
-      'libraries': [ "<!@(pkg-config --libs-only-l libsystemd-journal)" ]
+      'libraries': [ "<!@(pkg-config --libs-only-l libsystemd)" ]
     }
   ]
 }


### PR DESCRIPTION
`libsystem-journal` is deprecated and all functionality lives in `libsystemd`.

Fixes #13
